### PR TITLE
now using TMUX_BIN

### DIFF
--- a/mullvad.tmux
+++ b/mullvad.tmux
@@ -5,7 +5,7 @@
 #
 #  Part of https://github.com/jaclu/tmux-mullvad
 #
-#  Version: 2.1.1 2022-06-09
+#  Version: 2.1.2 2022-09-15
 #
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -37,7 +37,7 @@ set_tmux_option() {
     local option=$1
     local value=$2
 
-    tmux set-option -gq "$option" "$value"
+    $TMUX_BIN set-option -gq "$option" "$value"
 }
 
 

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -5,7 +5,7 @@
 #
 #  Part of https://github.com/jaclu/tmux-mullvad
 #
-#  Version: 2.1.1 2022-06-09
+#  Version: 2.1.1 2022-09-15
 #
 #  Things used in multiple scripts
 #
@@ -15,6 +15,16 @@
 #  locations, easily getting out of sync.
 #
 plugin_name="tmux-mullvad"
+
+#
+#  I use an env var TMUX_BIN to point at the current tmux, defined in my
+#  tmux.conf, in order to pick the version matching the server running.
+#  This is needed when checking backwards compatability with various versions.
+#  If not found, it is set to whatever is in path, so should have no negative
+#  impact. In all calls to tmux I use $TMUX_BIN instead in the rest of this
+#  plugin.
+#
+[ -z "$TMUX_BIN" ] && TMUX_BIN="tmux"
 
 #
 #  Summer 2022 - Mullvad has changed its status output in the beta
@@ -56,7 +66,7 @@ error_msg() {
     local exit_code="${2:-0}"
 
     log_it "$msg"
-    tmux display-message "$plugin_name $msg"
+    $TMUX_BIN display-message "$plugin_name $msg"
     [ "$exit_code" -ne 0 ] && exit "$exit_code"
 }
 
@@ -66,7 +76,7 @@ get_tmux_option() {
     local default_value=$2
     local option_value
 
-    option_value="$(tmux show-option -gqv "$option")"
+    option_value="$($TMUX_BIN show-option -gqv "$option")"
 
     if [[ -z "$option_value" ]]; then
         echo "$default_value"


### PR DESCRIPTION
In order to be able to test various versions of tmux for compatibility with plugins, I used ASDF.
This has the drawback of using ~/.asdf/shims/tmux thus not allowing the path to tmux itself to identify what tmux to run, so I have set up my tmux.conf to identify the actual tmux in that case. When using ASDF the actual path to tmux (example: ~/.asdf/installs/tmux/2.8/bin/tmux) is identified and stored in the env variable TMUX_BIN

Using $TMUX_BIN whenever the plugin needs to access tmux from the shell, ensures that the plugin uses the tmux associated with the running session. This makes my testing much more convenient since I don't have to kill my main tmux each time I want to test a specific version, I just run a separate tmux under the version being tested.
This should not have any impact if TMUX_BIN is not used, since then it defaults to just being 'tmux'